### PR TITLE
Additional detail around Custom Code conditions in Launch

### DIFF
--- a/help/extension-reference/core-extension/overview.md
+++ b/help/extension-reference/core-extension/overview.md
@@ -552,7 +552,7 @@ Set whether the user accepts cookies.
 
 #### Custom Code
 
-Specify any custom code that must exist as a condition of the event. Use the built-in code editor to enter the custom code.
+Specify any custom code that must exist as a condition of the event. Use the built-in code editor to enter the custom code. The custom code *must* return `true` to trigger an action or `false` to not trigger the action.
 
 1. Click **[!UICONTROL Open Editor]**.
 1. Type the custom code.

--- a/help/extension-reference/web/core-extension/overview.md
+++ b/help/extension-reference/web/core-extension/overview.md
@@ -276,7 +276,7 @@ Set whether the user accepts cookies.
 
 #### Custom Code
 
-Specify any custom code that must exist as a condition of the event. Use the built-in code editor to enter the custom code.
+Specify any custom code that must exist as a condition of the event. Use the built-in code editor to enter the custom code. Custom code *must* return true or false to enable or trigger an action.
 
 1. Click **[!UICONTROL Open Editor]**.
 1. Type the custom code.

--- a/help/extension-reference/web/core-extension/overview.md
+++ b/help/extension-reference/web/core-extension/overview.md
@@ -276,7 +276,7 @@ Set whether the user accepts cookies.
 
 #### Custom Code
 
-Specify any custom code that must exist as a condition of the event. Use the built-in code editor to enter the custom code. Custom code *must* return true or false to enable or trigger an action.
+Specify any custom code that must exist as a condition of the event. Use the built-in code editor to enter the custom code. The custom code *must* return `true` to trigger an action or `false` to not trigger the action.
 
 1. Click **[!UICONTROL Open Editor]**.
 1. Type the custom code.


### PR DESCRIPTION
Added some detail in the documentation around using the Custom Code option in Launch to condition a trigger in the core extension.