### PR TITLE
Added details about `event` variable within custom code.

### DIFF
--- a/help/extension-reference/web/core-extension/core-release-notes.md
+++ b/help/extension-reference/web/core-extension/core-release-notes.md
@@ -7,11 +7,17 @@ seo-description: Release notes for the Adobe Experience Platform Launch core ext
 
 # Core Extension Release Notes
 
+## November 1st, 2019
+
+v1.7.0
+
+* **Access to `event` Variable Within Custom Code Data Element** - A user can now reference the event from within a custom code data element when run within the context of a rule. The object will contain useful information about the event that triggered the rule. Many thanks to [Stewart Schilling](https://twitter.com/sdi_stewart) for this contribution.
+
 ## October 7th, 2019
 
 v1.6.2
 
-* **New Data Element 'Constant'** - The Core extension now includes a new data element called 'Constant'.  This can be used when you need to store a constant value that will be referenced in various conditions, actions or custom code. Many thanks to @janexner for this contribution.
+* **New "Constant" Data Element Type** - The Core extension now includes a new data element type called "Constant".  This can be used when you need to store a constant value that will be referenced in various conditions, actions or custom code. Many thanks to [Jan Exner](https://twitter.com/jexner) for this contribution.
 
 ## September 11, 2019
 

--- a/help/extension-reference/web/core-extension/overview.md
+++ b/help/extension-reference/web/core-extension/overview.md
@@ -564,6 +564,15 @@ Specify any custom code that must exist as a condition of the event. Use the bui
 1. Type the custom code.
 1. Click **[!UICONTROL Save]**.
 
+A variable named `event` will automatically be available that you may reference from within your custom code. The `event` object will contain useful information about the event that triggered the rule. The easiest way to determine what event data is available is to log `event` to the console from within your custom code:
+
+```javascipt
+console.log(event);
+return true;
+```
+
+Run the rule in a browser and inspect the logged event object in the browser's console. Once you understand what information is available, you can use it for programmitic decisioning within your custom code.
+
 #### Value Comparison
 
 Compares two values to determine whether this exception returns true.
@@ -830,6 +839,14 @@ Provide the code that runs after the event is triggered and conditions are evalu
 1. Click Open Editor.
 1. Edit the code, then click Save.
 
+When JavaScript is selected as the language, a variable named `event` will automatically be available that you may reference from within your custom code. The `event` object will contain useful information about the event that triggered the rule. The easiest way to determine what event data is available is to log `event` to the console from within your custom code:
+
+```javascipt
+console.log(event);
+```
+
+Run the rule in a browser and inspect the logged event object in the browser's console. Once you understand what information is available, you can use it for programmitic decisioning within your custom code, send a piece of the `event` object to a server, etc.
+
 ### Custom Code action processing
 
 The Core extension, available to all Launch users, contains a Custom Code action for executing user-provided JavaScript or HTML. It is often helpful for users to understand how rules with Custom Code actions are processed.
@@ -878,7 +895,7 @@ A return statement is necessary in the editor window in order to indicate what v
 
 **Example:**
 
-```text
+```javascript
 var pageType = $('div.page-wrapper').attr('class').split('')[1];
 if (window.location.pathname == '/') {
   return 'homepage';
@@ -886,6 +903,15 @@ if (window.location.pathname == '/') {
   return pageType;
 }
 ```
+
+If the custom code data element is being retrieved as part of a rule execution, a variable named `event` will automatically be available that you may reference from within your custom code. The `event` object will contain useful information about the event that triggered the rule. The easiest way to determine what event data is available is to log `event` to the console from within your custom code:
+
+```javascipt
+console.log(event);
+return true;
+```
+
+Run the rule in a browser and inspect the logged event object in the browser's console. Once you understand what information is available under the various rules that may use your data element, you can use it for programmitic decisioning within your custom code or return a piece of the `event` object as the data element's value.
 
 ### DOM attribute
 

--- a/help/extension-reference/web/core-extension/overview.md
+++ b/help/extension-reference/web/core-extension/overview.md
@@ -282,6 +282,15 @@ Specify any custom code that must exist as a condition of the event. Use the bui
 1. Type the custom code.
 1. Click **[!UICONTROL Save]**.
 
+A variable named `event` will automatically be available that you may reference from within your custom code. The `event` object will contain useful information about the event that triggered the rule. The easiest way to determine what event data is available is to log `event` to the console from within your custom code:
+
+```javascipt
+console.log(event);
+return true;
+```
+
+Run the rule in a browser and inspect the logged event object in the browser's console. Once you understand what information is available, you can use it for programmitic decisioning within your custom code.
+
 #### Value Comparison {#value-comparison}
 
 Compares two values to determine whether this condition returns true.


### PR DESCRIPTION
While the `event` variable has existed for a long time in the Custom Code condition and action types, it is a feature that will soon be released in the Custom Code data element type: https://github.com/adobe/reactor-extension-core/pull/7